### PR TITLE
Fix/plantavatars not returned

### DIFF
--- a/src/main/java/nl/novi/be_plantjesplanner/configuration/SecurityConfig.java
+++ b/src/main/java/nl/novi/be_plantjesplanner/configuration/SecurityConfig.java
@@ -51,8 +51,8 @@ public class SecurityConfig {
                         .requestMatchers("/login", "/users/register").permitAll()
                         .requestMatchers("/users/me").hasAnyRole("ADMIN", "DESIGNER")
                         .requestMatchers("/users/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.GET, "/plants/**").hasAnyRole("ADMIN","DESIGNER")
                         .requestMatchers("/plants/**").hasRole("ADMIN")
-                        .requestMatchers(HttpMethod.GET, "/plants/**").hasRole("DESIGNER")
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));

--- a/src/main/java/nl/novi/be_plantjesplanner/configuration/SecurityConfig.java
+++ b/src/main/java/nl/novi/be_plantjesplanner/configuration/SecurityConfig.java
@@ -46,14 +46,14 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())
                 .httpBasic(httpBasic -> httpBasic.disable())
-                .cors(cors -> {}) // voor CORS; configuratie kan via WebMvcConfigurer
+                .cors(cors -> {})
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/login", "/users/register").permitAll()
-                        .requestMatchers("/users/me").hasAnyRole("ADMIN", "DESIGNER")
+                        .requestMatchers("/login", "/users/register").permitAll()//create new designer is public
+                        .requestMatchers("/users/me").authenticated()//anyone with valid JWT
                         .requestMatchers("/users/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.GET, "/plants/**").hasAnyRole("ADMIN","DESIGNER")
                         .requestMatchers("/plants/**").hasRole("ADMIN")
-                        .anyRequest().authenticated()
+                        .anyRequest().authenticated()//todo: op denyAll() zetten als alle endpoints klaar zijn
                 )
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 

--- a/src/main/java/nl/novi/be_plantjesplanner/entities/ImageMetadata.java
+++ b/src/main/java/nl/novi/be_plantjesplanner/entities/ImageMetadata.java
@@ -13,10 +13,6 @@ public class ImageMetadata {
     private String storedFilename;
     private ZonedDateTime uploadDateTime;
 
-    @OneToOne(mappedBy = "plantAvatar")
-    private Plant plant;
-
-
     public ImageMetadata(){
         uploadDateTime = ZonedDateTime.now();
     }
@@ -63,11 +59,4 @@ public class ImageMetadata {
         this.uploadDateTime = ZonedDateTime.now();
     }
 
-    public Plant getPlant() {
-        return plant;
-    }
-
-    public void setPlant(Plant plant) {
-        this.plant = plant;
-    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,28 +1,36 @@
 
 spring.application.name=be_plantjesplanner
+
+#datasource
 spring.datasource.url=jdbc:postgresql://localhost:5432/plantjesplanner
 spring.datasource.username=springboot
 spring.datasource.password=springboot
-
-#the datastructure is generated from schema.sql, not Hibernate/JPA
-spring.jpa.generate-ddl=false
-
-
-spring.jpa.hibernate.ddl-auto=none
-#set to create-drop to create new tables on start-up and delete on shutdown
-#or set to update to preserve database between sessions todo: voor het inleveren op " Update" zetten
-
-#spring
 spring.sql.init.platform=postgres
 spring.jpa.database=postgresql
-#laat de sql commands zien
-spring.jpa.show-sql=true
 
-#create schema.sql first, then use data from data.sql to fix issues with setval
+#### Development database settings: database is reset with testdata on app restart ####
+#the datastructure is generated from schema.sql, not Hibernate/JPA
+spring.jpa.generate-ddl=false
+spring.jpa.hibernate.ddl-auto=none
+
+#create schema.sql first, then use data from data.sql (to fix issues with setval)
 spring.jpa.defer-datasource-initialization=true
 spring.sql.init.mode=always
 spring.sql.init.schema-locations=classpath:schema.sql
 spring.sql.init.data-locations=classpath:data.sql
+
+##additional logging options
+#show sql commands in console
+spring.jpa.show-sql=true
+#show logs from spring security
+logging.level.org.springframework.security=TRACE
+#########################################
+
+####Production database settings: database does not reset on app restart
+#spring.jpa.generate-ddl=false
+#spring.jpa.hibernate.ddl-auto=validate
+#spring.sql.init.mode=never
+##########################################
 
 #sizelimit for uploaded images by users is set to 2 MB
 spring.servlet.multipart.max-file-size=2MB

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,18 +4,16 @@ spring.datasource.url=jdbc:postgresql://localhost:5432/plantjesplanner
 spring.datasource.username=springboot
 spring.datasource.password=springboot
 
-#forces to generate the data structures
-spring.jpa.generate-ddl=true
+#the datastructure is generated from schema.sql, not Hibernate/JPA
+spring.jpa.generate-ddl=false
 
-spring.jpa.hibernate.ddl-auto=create-drop
-#spring.jpa.hibernate.ddl-auto=none
+
+spring.jpa.hibernate.ddl-auto=none
 #set to create-drop to create new tables on start-up and delete on shutdown
 #or set to update to preserve database between sessions todo: voor het inleveren op " Update" zetten
 
 #spring
 spring.sql.init.platform=postgres
-
-#JPA
 spring.jpa.database=postgresql
 #laat de sql commands zien
 spring.jpa.show-sql=true

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -16,7 +16,7 @@ VALUES
     (3, false, false, false, false, true, true, true, false, false, false, false, false);
 
 -- Insert Images
-INSERT INTO images (id, original_filename, stored_filename, upload_date_time)
+INSERT INTO image_metadata (id, original_filename, stored_filename, upload_date_time)
 VALUES (1, 'klimroos.jpg', 'klimroos.jpg', '2025-04-28T20:45:00+02:00'),
        (2, 'zonnebloem.jpg', 'zonnebloem.jpg', '2025-04-28T20:45:00+02:00'),
        (3, 'Hosta-Plant.jpg', 'Hosta-Plant.jpg', '2025-04-28T20:45:00+02:00');
@@ -44,7 +44,7 @@ VALUES
     (3, 'Hosta', 'Hosta sieboldiana', 'Schaduwminnende vaste plant met brede bladeren.', 0.6, 0.8, '#98FB98', 'GROEN', true, 3, 3, 3);
 
 -- 3. Sequences aanpassen
-SELECT setval('images_id_seq', (SELECT MAX(id) FROM images));
+SELECT setval('image_metadata_id_seq', (SELECT MAX(id) FROM image_metadata));
 SELECT setval('plants_id_seq', (SELECT MAX(id) FROM plants));
 SELECT setval('blooming_calendars_id_seq', (SELECT MAX(id) FROM blooming_calendars));
 SELECT setval('locales_id_seq', (SELECT MAX(id) FROM locales));

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,15 +1,13 @@
 
---clear tables
+--clear tables (for development only, remove DROP statements for PROD)
 
 DROP TABLE IF EXISTS plants CASCADE;
 DROP TABLE IF EXISTS authorities CASCADE;
 DROP TABLE IF EXISTS users CASCADE;
 DROP TABLE IF EXISTS design CASCADE;
-DROP TABLE IF EXISTS images CASCADE;
+DROP TABLE IF EXISTS image_metadata CASCADE;
 DROP TABLE IF EXISTS blooming_calendars CASCADE;
 DROP TABLE IF EXISTS locales CASCADE;
-
-
 
 -- 1. Table definitions for JDBC
 CREATE TABLE users (
@@ -27,8 +25,6 @@ CREATE TABLE authorities (
 CREATE UNIQUE INDEX ix_auth_username ON authorities (username, authority);
 
 -- 2. Table definitions for domain entities
-
-
 CREATE TABLE locales (
                          id SERIAL PRIMARY KEY,
                          sunlight VARCHAR(32) NOT NULL,
@@ -67,8 +63,6 @@ CREATE TABLE design (
                          username VARCHAR(255) NOT NULL,
                         CONSTRAINT fk_designs_users FOREIGN KEY (username) REFERENCES users(username) ON DELETE CASCADE
 );
-
-
 
 CREATE TABLE plants (
                         id SERIAL PRIMARY KEY,

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -54,7 +54,7 @@ CREATE TABLE blooming_calendars (
                                     december BOOLEAN NOT NULL
 );
 
-CREATE TABLE images (
+CREATE TABLE image_metadata (
                         id SERIAL PRIMARY KEY,
                         original_filename VARCHAR(255) NOT NULL,
                         stored_filename VARCHAR(255) NOT NULL,
@@ -82,6 +82,6 @@ CREATE TABLE plants (
                         published BOOLEAN DEFAULT false,
                         locale_id INTEGER REFERENCES locales(id),
                         blooming_calendar_id INTEGER REFERENCES blooming_calendars(id),
-                        plantavatar_id INTEGER REFERENCES images(id)
+                        plantavatar_id INTEGER REFERENCES image_metadata(id)
 );
 


### PR DESCRIPTION
bug fix for GET /plants/** requests that return no plant images or imagemetadata. Earlier I renamed the entity Image to indicate that the image files are stored in the OS filesystem, and that the database and plant objects only contain data about the files. Unfortunately I forgot to rename the tables in schema.sql and data.sql. Also adjusted application.properties to use schema.sql and not hibernate/JPA to build the database.  